### PR TITLE
fix: fixed parsing problem when there is no ref inside the include

### DIFF
--- a/src/gitlab_ci_ls_parser/handlers.rs
+++ b/src/gitlab_ci_ls_parser/handlers.rs
@@ -12,7 +12,7 @@ use regex::Regex;
 
 use crate::gitlab_ci_ls_parser::{
     parser_utils::ParserUtils, DiagnosticsNotification, NodeDefinition, PrepareRenameResult,
-    RenameResult,
+    RenameResult, DEFAULT_BRANCH_SUBFOLDER,
 };
 
 use super::{
@@ -467,7 +467,11 @@ impl LSPHandlers {
                 let file = remote.file?;
                 let file = parser_utils::ParserUtils::strip_quotes(&file).trim_start_matches('/');
 
-                let path = format!("{}/{}/{}", remote.project?, remote.reference?, file);
+                let path = if let Some(reference) = remote.reference {
+                    format!("{}/{}/{}", remote.project?, reference, file)
+                } else {
+                    format!("{}/{}/{}", remote.project?, DEFAULT_BRANCH_SUBFOLDER, file)
+                };
 
                 store
                     .keys()

--- a/src/gitlab_ci_ls_parser/mod.rs
+++ b/src/gitlab_ci_ls_parser/mod.rs
@@ -158,7 +158,7 @@ pub struct RemoteInclude {
 
 impl RemoteInclude {
     pub fn is_valid(&self) -> bool {
-        self.project.is_some() && self.reference.is_some() && self.file.is_some()
+        self.project.is_some() && self.file.is_some()
     }
 }
 
@@ -261,3 +261,5 @@ pub struct Component {
     pub local_path: String,
     pub inputs: Vec<ComponentInput>,
 }
+
+const DEFAULT_BRANCH_SUBFOLDER: &str = "default";

--- a/src/gitlab_ci_ls_parser/parser.rs
+++ b/src/gitlab_ci_ls_parser/parser.rs
@@ -55,7 +55,7 @@ struct Project {
     project: String,
 
     #[serde(rename = "ref")]
-    reference: String,
+    reference: Option<String>,
     file: Vec<String>,
 }
 
@@ -531,7 +531,7 @@ impl Parser for ParserImpl {
                     IncludeItem::Project(node) => {
                         let remote_files = match self.git.fetch_remote_repository(
                             node.project.as_str(),
-                            node.reference.as_str(),
+                            node.reference.as_deref(),
                             node.file,
                         ) {
                             Ok(rf) => rf,


### PR DESCRIPTION
I did two things here:
- When there is no ref inside the include statement the parser would error, I fixed that by making it optional
- There seemed also to be a non critical problem with the path, to where the repository is cloned. There was a slash missing inside the path between the cache path and the remote package. I changed this to work with the Path module to be a bit safer

Let me know if you want me to change anything, my Rust skills are not exactly fluent ;D