### PR TITLE
docs: suggest vim.filetype.add for Neovim

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,11 +65,10 @@ Easiest way to use this using neovim is to install it using [mason](https://gith
 Example how to add it:
 
 ```lua
-vim.api.nvim_create_autocmd({ "BufRead", "BufNewFile" }, {
-  pattern = "*.gitlab-ci*.{yml,yaml}",
-  callback = function()
-    vim.bo.filetype = "yaml.gitlab"
-  end,
+vim.filetype.add({
+  pattern = {
+    ['%.gitlab%-ci%.ya?ml'] = 'yaml.gitlab',
+  },
 })
 ```
 


### PR DESCRIPTION
https://neovim.io/doc/user/lua.html#vim.filetype.add()

Currently you have to manually configure repos in order to use names other than `.gitlab-ci.yml`, but `.gitlab-ci.yaml` will be another default eventually:
https://docs.gitlab.com/ci/pipelines/settings/#specify-a-custom-cicd-configuration-file
https://gitlab.com/gitlab-org/gitlab/-/issues/26169