### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -1,5 +1,7 @@
 ---
 name: CI
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/alesbrelih/gitlab-ci-ls/security/code-scanning/2](https://github.com/alesbrelih/gitlab-ci-ls/security/code-scanning/2)

To fix the problem, explicitly restrict the `GITHUB_TOKEN` permissions in the workflow. Since both `lint` and `test` jobs only need to read the repository contents (for `actions/checkout`), the minimal safe permission is `contents: read`. No job requires write access to issues, PRs, or other resources.

The best approach without changing functionality is to add a single `permissions` block at the workflow root level so it applies to all jobs that don’t override it. In `.github/workflows/ci.yaml`, insert:

```yaml
permissions:
  contents: read
```

after the `name: CI` line (or anywhere at the root level before `jobs:`). This change ensures that both `lint` and `test` run with a read-only `GITHUB_TOKEN`, satisfying CodeQL while preserving existing behavior.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
