### PR TITLE
feat: expand CI variables in include project and ref

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,26 @@ Initialization options:
 
 - **cache**: location for cached remote files
 - **log_path**: location for LS log
+- **variables**: map of CI variable names to values, used to expand `$VAR`/`${VAR}` occurrences in `include:` `project:` and `ref:` values. Variables not present in the map fall back to the process environment; unknown variables are left untouched. This is needed when includes are parameterized through instance- or group-level CI variables that only exist on the GitLab server. For example, every project on drupal.org's GitLab uses:
+
+  ```yaml
+  include:
+    - project: $_GITLAB_TEMPLATES_REPO
+      ref: $_GITLAB_TEMPLATES_REF
+      file: "/includes/include.drupalci.main.yml"
+  ```
+
+  which resolves with:
+
+  ```json
+  {
+    "variables": {
+      "_GITLAB_TEMPLATES_REPO": "project/gitlab_templates",
+      "_GITLAB_TEMPLATES_REF": "default-ref"
+    }
+  }
+  ```
+
 - **options**:
   - **dependencies_autocomplete_stage_filtering**: Items in dependencies options has to be from previous or current stage. This opption enables dependencies autocomplete result filtering by job stages. It is currently set as opt-in because it takes a longer time (cca 800ms on test repo - medium size) when stages aren't defined in root job because language server needs to first build whole job definition (merging extends) before it can check if job is a valid one. Defaults to `false`
 

--- a/src/gitlab_ci_ls_parser/handlers.rs
+++ b/src/gitlab_ci_ls_parser/handlers.rs
@@ -69,6 +69,7 @@ impl LSPHandlers {
             parser: Box::new(parser::ParserImpl::new(
                 cfg.remote_urls,
                 cfg.package_map,
+                cfg.variables,
                 cfg.cache_path,
                 Box::new(treesitter::TreesitterImpl::new()),
                 fs_utils,
@@ -572,11 +573,20 @@ impl LSPHandlers {
             } => {
                 let file = remote.file?;
                 let file = parser_utils::ParserUtils::strip_quotes(&file).trim_start_matches('/');
+                let project = parser_utils::ParserUtils::expand_variables(
+                    &remote.project?,
+                    &self.cfg.variables,
+                );
 
                 let path = if let Some(reference) = remote.reference {
-                    format!("{}/{}/{}", remote.project?, reference, file)
+                    let reference = parser_utils::ParserUtils::expand_variables(
+                        &reference,
+                        &self.cfg.variables,
+                    );
+
+                    format!("{project}/{reference}/{file}")
                 } else {
-                    format!("{}/{}/{}", remote.project?, DEFAULT_BRANCH_SUBFOLDER, file)
+                    format!("{project}/{DEFAULT_BRANCH_SUBFOLDER}/{file}")
                 };
 
                 store
@@ -2182,7 +2192,10 @@ impl LSPHandlers {
                 c.is_whitespace() || c == '"' || c == '\'' || c == '/' || c == '\\'
             });
 
+        let project = ParserUtils::expand_variables(project, &self.cfg.variables);
         let path = if let Some(reference) = &remote.reference {
+            let reference = ParserUtils::expand_variables(reference, &self.cfg.variables);
+
             format!("{project}/{reference}/")
         } else {
             format!("{project}/{DEFAULT_BRANCH_SUBFOLDER}/")

--- a/src/gitlab_ci_ls_parser/mod.rs
+++ b/src/gitlab_ci_ls_parser/mod.rs
@@ -171,6 +171,7 @@ pub struct LSPConfig {
     pub cache_path: String,
     pub package_map: HashMap<String, String>,
     pub remote_urls: Vec<String>,
+    pub variables: HashMap<String, String>,
     pub experimental: LSPExperimental,
 }
 

--- a/src/gitlab_ci_ls_parser/parser.rs
+++ b/src/gitlab_ci_ls_parser/parser.rs
@@ -77,6 +77,7 @@ pub trait Parser: Sync {
 #[allow(clippy::module_name_repetitions)]
 pub struct ParserImpl {
     treesitter: Box<dyn treesitter::Treesitter>,
+    variables: HashMap<String, String>,
     git: Box<dyn git::Git>,
 }
 
@@ -98,12 +99,14 @@ impl ParserImpl {
     pub fn new(
         remote_urls: Vec<String>,
         package_map: HashMap<String, String>,
+        variables: HashMap<String, String>,
         cache_path: String,
         treesitter: Box<dyn treesitter::Treesitter>,
         fs_utils: Box<dyn fs_utils::FSUtils>,
     ) -> ParserImpl {
         ParserImpl {
             treesitter,
+            variables,
             git: Box::new(git::GitImpl::new(
                 remote_urls,
                 package_map,
@@ -545,9 +548,14 @@ impl Parser for ParserImpl {
                         }
                     }
                     IncludeItem::Project(node) => {
+                        let project = ParserUtils::expand_variables(&node.project, &self.variables);
+                        let reference = node
+                            .reference
+                            .map(|r| ParserUtils::expand_variables(&r, &self.variables));
+
                         let remote_files = match self.git.fetch_remote_repository(
-                            node.project.as_str(),
-                            node.reference.as_deref(),
+                            project.as_str(),
+                            reference.as_deref(),
                             node.file,
                         ) {
                             Ok(rf) => rf,
@@ -741,6 +749,7 @@ mod tests {
         let parser = ParserImpl::new(
             vec![],
             HashMap::new(),
+            HashMap::new(),
             String::new(),
             Box::new(TreesitterImpl::new()),
             Box::new(MockFSUtils::new()),
@@ -920,6 +929,7 @@ mod tests {
     fn test_get_full_definition() {
         let parser = ParserImpl::new(
             vec![],
+            HashMap::new(),
             HashMap::new(),
             String::new(),
             Box::new(TreesitterImpl::new()),

--- a/src/gitlab_ci_ls_parser/parser_utils.rs
+++ b/src/gitlab_ci_ls_parser/parser_utils.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::env;
 
 use super::GitlabElement;
@@ -304,6 +305,27 @@ impl ParserUtils {
 
         results
     }
+
+    // Expands $VAR and ${VAR} using the given variables map, falling back to
+    // process environment variables. Unknown variables are left untouched.
+    pub fn expand_variables(input: &str, variables: &HashMap<String, String>) -> String {
+        let re = regex::Regex::new(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}|\$([A-Za-z_][A-Za-z0-9_]*)")
+            .expect("Invalid REGEX");
+
+        re.replace_all(input, |caps: &regex::Captures| {
+            let name = caps
+                .get(1)
+                .or_else(|| caps.get(2))
+                .expect("one group always matches")
+                .as_str();
+
+            match variables.get(name) {
+                Some(value) => value.clone(),
+                None => env::var(name).unwrap_or_else(|_| caps[0].to_string()),
+            }
+        })
+        .to_string()
+    }
 }
 
 #[cfg(test)]
@@ -441,5 +463,53 @@ mod tests {
         let adjusted = ParserUtils::adjust_to_char_boundary(line, char_idx);
 
         assert_eq!(adjusted, char_idx);
+    }
+
+    #[test]
+    fn test_expand_variables_from_map() {
+        let variables = HashMap::from([(
+            "_GITLAB_TEMPLATES_REPO".to_string(),
+            "project/gitlab_templates".to_string(),
+        )]);
+
+        assert_eq!(
+            ParserUtils::expand_variables("$_GITLAB_TEMPLATES_REPO", &variables),
+            "project/gitlab_templates"
+        );
+        assert_eq!(
+            ParserUtils::expand_variables("${_GITLAB_TEMPLATES_REPO}", &variables),
+            "project/gitlab_templates"
+        );
+    }
+
+    #[test]
+    fn test_expand_variables_from_environment() {
+        with_var("EXPAND_TEST_REF", Some("main"), || {
+            assert_eq!(
+                ParserUtils::expand_variables("$EXPAND_TEST_REF", &HashMap::new()),
+                "main"
+            );
+        });
+    }
+
+    #[test]
+    fn test_expand_variables_map_wins_over_environment() {
+        with_var("EXPAND_TEST_REF", Some("from-env"), || {
+            let variables =
+                HashMap::from([("EXPAND_TEST_REF".to_string(), "from-map".to_string())]);
+
+            assert_eq!(
+                ParserUtils::expand_variables("$EXPAND_TEST_REF", &variables),
+                "from-map"
+            );
+        });
+    }
+
+    #[test]
+    fn test_expand_variables_unknown_left_untouched() {
+        assert_eq!(
+            ParserUtils::expand_variables("$THIS_IS_NOT_DEFINED_ANYWHERE/x", &HashMap::new()),
+            "$THIS_IS_NOT_DEFINED_ANYWHERE/x"
+        );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,6 +32,9 @@ struct InitializationOptions {
     #[serde(default = "default_package_map")]
     package_map: HashMap<String, String>,
 
+    #[serde(default = "default_variables")]
+    variables: HashMap<String, String>,
+
     #[serde(default = "default_log_path")]
     log_path: String,
 
@@ -83,6 +86,7 @@ fn default_options() -> Options {
 fn default_initialization_options() -> InitializationOptions {
     InitializationOptions {
         package_map: default_package_map(),
+        variables: default_variables(),
         log_path: default_log_path(),
         cache_path: default_cache_path(),
         options: default_options(),
@@ -94,6 +98,10 @@ fn default_dependencies_autocomplete_stage_filtering() -> bool {
 }
 
 fn default_package_map() -> HashMap<String, String> {
+    HashMap::new()
+}
+
+fn default_variables() -> HashMap<String, String> {
     HashMap::new()
 }
 
@@ -167,6 +175,7 @@ fn main() -> Result<(), Box<dyn Error + Sync + Send>> {
                     initialization_options: InitializationOptions {
                         log_path: default_log_path(),
                         package_map: HashMap::new(),
+                        variables: HashMap::new(),
                         cache_path: default_cache_path(),
                         options: Options {
                             dependencies_autocomplete_stage_filtering:
@@ -211,6 +220,7 @@ fn main() -> Result<(), Box<dyn Error + Sync + Send>> {
                 .to_string_lossy()
                 .to_string(),
             package_map: init_params.initialization_options.package_map.clone(),
+            variables: init_params.initialization_options.variables.clone(),
             remote_urls,
             root_dir: init_params.get_root().clone(),
             experimental: LSPExperimental {


### PR DESCRIPTION
## Problem

Includes can be parameterized with CI variables defined at the instance or group level, which never appear anywhere in the repository:

```yaml
include:
  - project: $_GITLAB_TEMPLATES_REPO
    ref: $_GITLAB_TEMPLATES_REF
    file: "/includes/include.drupalci.main.yml"
```

These values are currently passed to `git clone` verbatim, so the clone fails, nothing from the included files is indexed, and go-to-definition/completion/diagnostics for anything defined in them silently does nothing.

This is not a niche pattern. The snippet above is the standard, documented CI boilerplate on drupal.org's GitLab instance, where `_GITLAB_TEMPLATES_REPO` and `_GITLAB_TEMPLATES_REF` are instance-level variables resolving to `project/gitlab_templates` and `default-ref`. Every Drupal core and contrib project that runs CI there — thousands of repositories — uses this indirection so the Drupal Association can move all projects to a new templates release at once. None of them can currently resolve their includes in the editor.

## Change

Adds a `variables` initialization option mapping CI variable names to values, and expands `$VAR`/`${VAR}` in the `project` and `ref` values at the three places they are consumed: fetching the remote repository, resolving go-to-definition, and completing remote file paths.

```json
{
  "variables": {
    "_GITLAB_TEMPLATES_REPO": "project/gitlab_templates",
    "_GITLAB_TEMPLATES_REF": "default-ref"
  }
}
```

Resolution order is the configured map first, then the process environment (consistent with the existing `CI_SERVER_FQDN` handling in `extract_component_from_uri`). Unknown variables are left untouched rather than expanded to an empty string, so a missing entry degrades to today's behavior instead of cloning a wrong path.

## Compatibility

The option defaults to an empty map and expansion is a no-op on strings without `$`, so nothing changes for projects that do not configure it.

## Testing

Four unit tests cover expansion from the map, from the environment, map-wins-over-environment precedence, and unknown variables being left alone. Full suite passes (61 tests). `cargo fmt --check` is clean; `cargo clippy` reports no new findings (the existing findings on a current toolchain are unchanged from main).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)
